### PR TITLE
문제 답변 페이지 저장, 수정, 삭제 기능 구현

### DIFF
--- a/src/app/api/answers/componsts/AnswerPreviewCard.tsx
+++ b/src/app/api/answers/componsts/AnswerPreviewCard.tsx
@@ -1,0 +1,24 @@
+"use client";
+import { Card } from "@/components/ui/card";
+export default function AnswerPreviewCard() {
+  return (
+    <Card>
+      <div className="flex gap-4 items-center mb-6">
+        <p className="line-clamp-2">
+          s not simply random text. It has roots in a piece of classical Latin literature from 45
+          BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney
+          College in Virginiaer 2000 years old. Richard McClintock, a Latin professor at
+          Hampden-Sydney College in Virginia
+        </p>
+        <span className="w-[32px] h-[32px] inline-block bg-[var(--gray-01)] rounded-full shrink-0"></span>
+      </div>
+      <div className="flex justify-between">
+        <span>
+          <span className="txt-sm !text-[var(--gray-02)] mr-2">2020.20.20</span>
+          <span className="txt-sm !text-[var(--gray-02)]">작성자 이름</span>
+        </span>
+        <span className="txt-sm !text-[var(--gray-02)]">좋아요 100</span>
+      </div>
+    </Card>
+  );
+}

--- a/src/app/api/answers/route.ts
+++ b/src/app/api/answers/route.ts
@@ -5,12 +5,6 @@ import { CreatedAnswerDto } from "@/application/answer/dto/CreatedAnswerDto";
 import { SbAnswerRepository } from "@/infra/repositories/supabase/SbAnswerRepository";
 import { NextResponse } from "next/server";
 
-interface RequestParams {
-  params: {
-    id: number; //questionId
-  };
-}
-
 //답변 저장
 export async function POST(request: Request) {
   try {
@@ -48,8 +42,8 @@ export async function DELETE(request: Request) {
   }
 }
 
-//답변 조회
-export async function GET(request: Request) {}
-
 //답변 수정
 export async function PUT(request: Request) {}
+
+//답변 조회
+export async function GET(request: Request) {}

--- a/src/app/api/answers/route.ts
+++ b/src/app/api/answers/route.ts
@@ -1,0 +1,61 @@
+import { CreateAnswerUsecase } from "@/application/usecase/answer/CreateAnswerUsecase";
+import { DeleteAnswerUsecase } from "@/application/usecase/answer/DeleteAnswerUsecase";
+import { CreateAnswerDto } from "@/application/usecase/answer/dto/CreateAnswerDto";
+import { CreatedAnswerDto } from "@/application/usecase/answer/dto/CreatedAnswerDto";
+import { SbAnswerRepository } from "@/infra/repositories/supabase/SbAnswerRepository";
+import { NextResponse } from "next/server";
+
+interface RequestParams {
+  params: {
+    id: number; //questionId
+  };
+}
+
+//답변 저장
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { userId, questionId, content } = body;
+
+    if (!userId || !questionId || !content) {
+      return NextResponse.json({ error: "모든 필드를 입력해주세요." }, { status: 400 });
+    }
+    const answerDto = new CreateAnswerDto(body.userId, body.questionId, body.content, new Date());
+
+    const createAnswerUsecase = new CreateAnswerUsecase(new SbAnswerRepository());
+    const createdAnswerDto: CreatedAnswerDto = await createAnswerUsecase.execute(answerDto);
+    return NextResponse.json(
+      { message: "답변 등록 완료", data: createdAnswerDto },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error("Error creating answer:", error);
+    return NextResponse.json({ error: "답변 생성 실패" }, { status: 500 });
+  }
+}
+
+//답변 삭제
+export async function DELETE(request: Request, { params }: RequestParams) {
+  const { id: questionId } = params;
+
+  if (!questionId) {
+    return NextResponse.json({ error: "문제 ID가 필요합니다" }, { status: 400 });
+  }
+  const body = await request.json();
+  const { userId } = body;
+
+  try {
+    const usecase = new DeleteAnswerUsecase(new SbAnswerRepository());
+    await usecase.execute({ userId, questionId });
+    return NextResponse.json({ message: "삭제 완료" });
+  } catch (error) {
+    console.error("삭제 실패:", error);
+    return NextResponse.json({ error: "삭제 실패" }, { status: 500 });
+  }
+}
+
+//답변 조회
+export async function GET(request: Request) {}
+
+//답변 수정
+export async function PUT(request: Request) {}

--- a/src/app/api/answers/route.ts
+++ b/src/app/api/answers/route.ts
@@ -1,7 +1,7 @@
-import { CreateAnswerUsecase } from "@/application/usecase/answer/CreateAnswerUsecase";
-import { DeleteAnswerUsecase } from "@/application/usecase/answer/DeleteAnswerUsecase";
-import { CreateAnswerDto } from "@/application/usecase/answer/dto/CreateAnswerDto";
-import { CreatedAnswerDto } from "@/application/usecase/answer/dto/CreatedAnswerDto";
+import { CreateAnswerUsecase } from "@/application/answer/CreateAnswerUsecase";
+import { DeleteAnswerUsecase } from "@/application/answer/DeleteAnswerUsecase";
+import { CreateAnswerDto } from "@/application/answer/dto/CreateAnswerDto";
+import { CreatedAnswerDto } from "@/application/answer/dto/CreatedAnswerDto";
 import { SbAnswerRepository } from "@/infra/repositories/supabase/SbAnswerRepository";
 import { NextResponse } from "next/server";
 

--- a/src/app/api/answers/route.ts
+++ b/src/app/api/answers/route.ts
@@ -35,15 +35,9 @@ export async function POST(request: Request) {
 }
 
 //답변 삭제
-export async function DELETE(request: Request, { params }: RequestParams) {
-  const { id: questionId } = params;
-
-  if (!questionId) {
-    return NextResponse.json({ error: "문제 ID가 필요합니다" }, { status: 400 });
-  }
+export async function DELETE(request: Request) {
   const body = await request.json();
-  const { userId } = body;
-
+  const { userId, questionId } = body;
   try {
     const usecase = new DeleteAnswerUsecase(new SbAnswerRepository());
     await usecase.execute({ userId, questionId });

--- a/src/app/api/answers/route.ts
+++ b/src/app/api/answers/route.ts
@@ -2,6 +2,8 @@ import { CreateAnswerUsecase } from "@/application/answer/CreateAnswerUsecase";
 import { DeleteAnswerUsecase } from "@/application/answer/DeleteAnswerUsecase";
 import { CreateAnswerDto } from "@/application/answer/dto/CreateAnswerDto";
 import { CreatedAnswerDto } from "@/application/answer/dto/CreatedAnswerDto";
+import { UpdateAnswerDto } from "@/application/answer/dto/UpdateAnswerDto";
+import { UpdateAnswerUsecase } from "@/application/answer/UpdateAnswerUsecase";
 import { SbAnswerRepository } from "@/infra/repositories/supabase/SbAnswerRepository";
 import { NextResponse } from "next/server";
 
@@ -11,11 +13,7 @@ export async function POST(request: Request) {
     const body = await request.json();
     const { userId, questionId, content } = body;
 
-    if (!userId || !questionId || !content) {
-      return NextResponse.json({ error: "모든 필드를 입력해주세요." }, { status: 400 });
-    }
-    const answerDto = new CreateAnswerDto(body.userId, body.questionId, body.content, new Date());
-
+    const answerDto = new CreateAnswerDto(userId, questionId, content, new Date());
     const createAnswerUsecase = new CreateAnswerUsecase(new SbAnswerRepository());
     const createdAnswerDto: CreatedAnswerDto = await createAnswerUsecase.execute(answerDto);
     return NextResponse.json(
@@ -24,7 +22,7 @@ export async function POST(request: Request) {
     );
   } catch (error) {
     console.error("Error creating answer:", error);
-    return NextResponse.json({ error: "답변 생성 실패" }, { status: 500 });
+    return NextResponse.json({ error: "답변 등록 실패" }, { status: 500 });
   }
 }
 
@@ -35,15 +33,28 @@ export async function DELETE(request: Request) {
   try {
     const usecase = new DeleteAnswerUsecase(new SbAnswerRepository());
     await usecase.execute({ userId, questionId });
-    return NextResponse.json({ message: "삭제 완료" });
+    return NextResponse.json({ message: "답변 삭제 완료" });
   } catch (error) {
     console.error("삭제 실패:", error);
-    return NextResponse.json({ error: "삭제 실패" }, { status: 500 });
+    return NextResponse.json({ error: "답변 삭제 실패" }, { status: 500 });
   }
 }
 
 //답변 수정
-export async function PUT(request: Request) {}
+export async function PUT(request: Request) {
+  try {
+    const body = await request.json();
+    const { userId, questionId, content } = body;
+
+    const answerDto = new UpdateAnswerDto(userId, questionId, content);
+    const updateAnswerUsecase = new UpdateAnswerUsecase(new SbAnswerRepository());
+    const updateAnswerDto: CreatedAnswerDto = await updateAnswerUsecase.execute(answerDto);
+    return NextResponse.json({ message: "답변 수정 완료", data: updateAnswerDto }, { status: 201 });
+  } catch (error) {
+    console.error("Error creating answer:", error);
+    return NextResponse.json({ error: "답변 수정 실패" }, { status: 500 });
+  }
+}
 
 //답변 조회
 export async function GET(request: Request) {}

--- a/src/app/questions/[questionid]/page.tsx
+++ b/src/app/questions/[questionid]/page.tsx
@@ -6,7 +6,6 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { useAuthStore } from "@/store/useAuthStore";
-import { useSearchParams } from "next/navigation";
 
 interface Props {
   params: {

--- a/src/app/questions/[questionid]/page.tsx
+++ b/src/app/questions/[questionid]/page.tsx
@@ -21,7 +21,7 @@ export default function AnswerFormPage({ params }: Props) {
   const [tab, setTab] = useState<string>("tab1");
   const [isBookmarked, setIsBookmarked] = useState<boolean>(false);
   const [isSubmit, setIsSubmit] = useState(false);
-  const [isEditing, setIsEditing] = useState(false);
+  const [isEditing, setIsEditing] = useState(true);
   const token = useAuthStore((state) => state.token);
   const user = useAuthStore((state) => state.user);
   const userEmail = user?.email;
@@ -38,7 +38,7 @@ export default function AnswerFormPage({ params }: Props) {
     }
     const formData = {
       userId: userEmail,
-      questionId,
+      questionId: 6,
       content,
     };
     try {
@@ -55,6 +55,7 @@ export default function AnswerFormPage({ params }: Props) {
       }
       alert(action === "create" ? "답변이 저장되었습니다." : "답변이 변경되었습니다.");
       setIsSubmit(true);
+      setIsEditing(false);
     } catch (error) {
       alert(`${action === "create" ? "답변 저장" : "답변 변경"} 실패: ${(error as Error).message}`);
     }

--- a/src/app/questions/[questionid]/page.tsx
+++ b/src/app/questions/[questionid]/page.tsx
@@ -4,8 +4,9 @@ import Image from "next/image";
 import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
+
 import { useAuthStore } from "@/store/useAuthStore";
+import AnswerPreviewCard from "@/app/api/answers/componsts/AnswerPreviewCard";
 
 interface Props {
   params: {
@@ -20,6 +21,7 @@ export default function AnswerFormPage({ params }: Props) {
   const [tab, setTab] = useState<string>("tab1");
   const [isBookmarked, setIsBookmarked] = useState<boolean>(false);
   const [isSubmit, setIsSubmit] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
   const token = useAuthStore((state) => state.token);
   const user = useAuthStore((state) => state.user);
   const userEmail = user?.email;
@@ -116,6 +118,7 @@ export default function AnswerFormPage({ params }: Props) {
               className="box-border p-[24px] h-[500px] border border-[var(--blue-03)] radius mt-6 w-full resize-none focus:ring-1 focus:ring-[var(--blue-03)] focus:outline-none"
               placeholder="내용을 입력하세요..."
               ref={answerRef}
+              disabled={!isEditing}
             ></textarea>
           </TabsContent>
           <TabsContent value="tab2">
@@ -126,51 +129,41 @@ export default function AnswerFormPage({ params }: Props) {
             ></textarea>
           </TabsContent>
         </Tabs>
-        <div className="flex justify-center mt-[24px]">
-          {/* 이미 기존에 작성한 답변이 있으면 */}
-          {isSubmit && (
-            <div className="flex gap-2">
-              <Button
-                variant="outline"
-                size="lg"
-                type="button"
-                onClick={() => handleSaveAnswer("update")}
-              >
-                수정
+        {tab === "tab1" && (
+          <div className="flex justify-center mt-[24px]">
+            {/* 이미 기존에 작성한 답변이 있으면 수정 삭제 먼저 */}
+            {isSubmit && (
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  size="lg"
+                  type="button"
+                  onClick={() => {
+                    if (isEditing) {
+                      handleSaveAnswer("update");
+                    }
+                    setIsEditing((prev) => !prev);
+                  }}
+                >
+                  {isEditing ? "저장" : "수정"}
+                </Button>
+                <Button variant="gray" size="lg" type="button" onClick={handleDeleteAnswer}>
+                  삭제
+                </Button>
+              </div>
+            )}
+            {!isSubmit && (
+              <Button size="lg" type="button" onClick={() => handleSaveAnswer("create")}>
+                저장
               </Button>
-              <Button variant="gray" size="lg" type="button" onClick={handleDeleteAnswer}>
-                삭제
-              </Button>
-            </div>
-          )}
-          {!isSubmit && (
-            <Button size="lg" type="button" onClick={() => handleSaveAnswer("create")}>
-              저장
-            </Button>
-          )}
-        </div>
+            )}
+          </div>
+        )}
       </form>
       <div className="pt-[150px] pb-[150px]">
         <h3 className="txt-2xl-b pb-6">다른 사람 답변 확인하기</h3>
         <div className="grid grid-cols-2 grid-rows-auto gap-x-16 gap-y-24">
-          <Card>
-            <div className="flex gap-4 items-center mb-6">
-              <p className="line-clamp-2">
-                s not simply random text. It has roots in a piece of classical Latin literature from
-                45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at
-                Hampden-Sydney College in Virginiaer 2000 years old. Richard McClintock, a Latin
-                professor at Hampden-Sydney College in Virginia
-              </p>
-              <span className="w-[32px] h-[32px] inline-block bg-[var(--gray-01)] rounded-full shrink-0"></span>
-            </div>
-            <div className="flex justify-between">
-              <span>
-                <span className="txt-sm !text-[var(--gray-02)] mr-2">2020.20.20</span>
-                <span className="txt-sm !text-[var(--gray-02)]">작성자 이름</span>
-              </span>
-              <span className="txt-sm !text-[var(--gray-02)]">좋아요 100</span>
-            </div>
-          </Card>
+          <AnswerPreviewCard />
         </div>
       </div>
     </div>

--- a/src/app/questions/[questionid]/page.tsx
+++ b/src/app/questions/[questionid]/page.tsx
@@ -36,7 +36,7 @@ export default function AnswerFormPage({ params }: Props) {
     }
     const formData = {
       userId: userEmail,
-      questionId: 4,
+      questionId,
       content,
     };
     try {

--- a/src/app/questions/[questionid]/page.tsx
+++ b/src/app/questions/[questionid]/page.tsx
@@ -19,32 +19,27 @@ export default function AnswerFormPage({ params }: Props) {
   console.log("searchParams", searchParams);
   const [tab, setTab] = useState<string>("tab1");
   const [isBookmarked, setIsBookmarked] = useState<boolean>(false);
-  const contentRef = useRef<string>("");
+  const answerRef = useRef<HTMLTextAreaElement>(null);
   const [isSubmit, setIsSubmit] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
   const token = useAuthStore((state) => state.token);
   const user = useAuthStore((state) => state.user);
   const handleToggleBookmark = () => setIsBookmarked((prev) => !prev);
-  const handleInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    contentRef.current = e.target.value;
-  };
 
+  console.log("user", user);
   //이전에 작성한 답변 불러오기
-
+  const userEmail = user?.email;
   //답변 저장
   const handleSaveAnswer = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    const content = contentRef.current;
+    const content = answerRef.current?.value || "";
     if (!content.trim()) {
       alert("내용을 입력해주세요.");
       return;
     }
-
-    // const { user } = useAuthStore();
-    console.log(content);
     const formData = {
-      userId: "leekjoo1008@gmail.com",
-      questionId: 1,
+      userId: userEmail,
+      questionId: 3,
       content,
     };
     console.log(formData);
@@ -71,8 +66,6 @@ export default function AnswerFormPage({ params }: Props) {
 
   //답변 삭제
   const handleDeleteAnswer = async () => {
-    console.log("ss");
-    //답변 삭제여부 확인 추가하기
     try {
       const response = await fetch(`/api/answers`, {
         method: "DELETE",
@@ -81,14 +74,17 @@ export default function AnswerFormPage({ params }: Props) {
           Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify({
-          userId: user?.id,
+          userId: userEmail,
+          questionId: 3,
         }),
       });
       if (!response.ok) {
         throw new Error("답변 삭제 실패");
       }
       alert("답변이 삭제되었습니다.");
-      contentRef.current = "";
+      if (answerRef.current) {
+        answerRef.current.value = "";
+      }
     } catch (error) {
       console.error("저장 중 오류 발생:", error);
       alert("답변 저장 실패: " + (error as Error).message);
@@ -97,10 +93,10 @@ export default function AnswerFormPage({ params }: Props) {
 
   //답변 수정
   const handleEditContent = async () => {
-    const content = contentRef.current;
+    const content = answerRef.current;
     if (isEditing) {
       const formData = {
-        userId: user?.email,
+        userId: userEmail,
         questionId: 1,
         content,
       };
@@ -156,7 +152,7 @@ export default function AnswerFormPage({ params }: Props) {
             <textarea
               className="box-border p-[24px] h-[500px] border border-[var(--blue-03)] radius mt-6 w-full resize-none focus:ring-1 focus:ring-[var(--blue-03)] focus:outline-none"
               placeholder="내용을 입력하세요..."
-              onChange={handleInputChange}
+              ref={answerRef}
             ></textarea>
           </TabsContent>
           <TabsContent value="tab2">

--- a/src/application/answer/CreateAnswerUsecase.ts
+++ b/src/application/answer/CreateAnswerUsecase.ts
@@ -1,0 +1,19 @@
+import { Answer } from "@/domain/entities/Answer";
+import { AnswerRepository } from "@/domain/repositories/AnswerRepository";
+import { CreateAnswerDto } from "./dto/CreateAnswerDto";
+
+export class CreateAnswerUsecase {
+  constructor(private readonly answerRepository: AnswerRepository) {}
+  //답변을 만들기 위한 입력 데이터 객체 (DTO)         //리턴값
+  async execute(createDto: CreateAnswerDto): Promise<Answer> {
+    const { userId, questionId, content } = createDto;
+    if (!createDto.userId) {
+      //로그인 페이지로 이동 추가
+      throw new Error("회원이 아닙니다.");
+    }
+
+    const answer = new Answer(userId, questionId, content, new Date());
+    const newAnswer = await this.answerRepository.createAnswer(answer);
+    return newAnswer;
+  }
+}

--- a/src/application/answer/DeleteAnswerUsecase.ts
+++ b/src/application/answer/DeleteAnswerUsecase.ts
@@ -1,0 +1,11 @@
+import { AnswerRepository } from "@/domain/repositories/AnswerRepository";
+
+export class DeleteAnswerUsecase {
+  constructor(private readonly answerRepository: AnswerRepository) {}
+
+  async execute(dto: { userId: string; questionId: number }): Promise<void> {
+    const { userId, questionId } = dto;
+
+    await this.answerRepository.deleteAnswer({ userId, questionId });
+  }
+}

--- a/src/application/answer/UpdateAnswerUsecase.ts
+++ b/src/application/answer/UpdateAnswerUsecase.ts
@@ -1,0 +1,19 @@
+import { Answer } from "@/domain/entities/Answer";
+
+import { UpdateAnswerDto } from "./dto/UpdateAnswerDto";
+import { AnswerRepository } from "@/domain/repositories/AnswerRepository";
+
+export class UpdateAnswerUsecase {
+  constructor(private readonly answerRepo: AnswerRepository) {}
+
+  async execute(updateDto: UpdateAnswerDto): Promise<Answer> {
+    const answer = new Answer(
+      updateDto.userId,
+      updateDto.questionId,
+      updateDto.content,
+      new Date()
+    );
+
+    return await this.answerRepo.updateAnswer(answer);
+  }
+}

--- a/src/application/answer/UpdateAnswerUsecase.ts
+++ b/src/application/answer/UpdateAnswerUsecase.ts
@@ -7,12 +7,8 @@ export class UpdateAnswerUsecase {
   constructor(private readonly answerRepo: AnswerRepository) {}
 
   async execute(updateDto: UpdateAnswerDto): Promise<Answer> {
-    const answer = new Answer(
-      updateDto.userId,
-      updateDto.questionId,
-      updateDto.content,
-      new Date()
-    );
+    const { userId, questionId, content } = updateDto;
+    const answer = new Answer(userId, questionId, content);
 
     return await this.answerRepo.updateAnswer(answer);
   }

--- a/src/application/answer/dto/CreateAnswerDto.ts
+++ b/src/application/answer/dto/CreateAnswerDto.ts
@@ -1,5 +1,6 @@
-export class Answer {
+export class CreateAnswerDto {
   constructor(
+    //문제 답변 저장
     public userId: string,
     public questionId: number,
     public content: string,

--- a/src/application/answer/dto/CreatedAnswerDto.ts
+++ b/src/application/answer/dto/CreatedAnswerDto.ts
@@ -1,0 +1,6 @@
+export class CreatedAnswerDto {
+  constructor(
+    //문제 답변이 작성되어있으면 불러오기
+    public content: string
+  ) {}
+}

--- a/src/application/answer/dto/DeleteAnswerDto.ts
+++ b/src/application/answer/dto/DeleteAnswerDto.ts
@@ -1,0 +1,6 @@
+export class DeleteAnswerDto {
+  constructor(
+    public userId: string,
+    public questionId: number
+  ) {}
+}

--- a/src/application/answer/dto/UpdateAnswerDto.ts
+++ b/src/application/answer/dto/UpdateAnswerDto.ts
@@ -1,4 +1,4 @@
-export class Answer {
+export class UpdateAnswerDto {
   constructor(
     public userId: string,
     public questionId: number,

--- a/src/application/answer/dto/UpdateAnswerDto.ts
+++ b/src/application/answer/dto/UpdateAnswerDto.ts
@@ -2,7 +2,6 @@ export class UpdateAnswerDto {
   constructor(
     public userId: string,
     public questionId: number,
-    public content: string,
-    public createdAt: Date
+    public content: string
   ) {}
 }

--- a/src/domain/entities/Answer.ts
+++ b/src/domain/entities/Answer.ts
@@ -4,6 +4,6 @@ export class Answer {
     public questionId: number,
     public content: string,
     public createdAt?: Date,
-    public updaredAt?: Date
+    public updatedAt?: Date
   ) {}
 }

--- a/src/domain/entities/Answer.ts
+++ b/src/domain/entities/Answer.ts
@@ -3,6 +3,7 @@ export class Answer {
     public userId: string,
     public questionId: number,
     public content: string,
-    public createdAt: Date
+    public createdAt?: Date,
+    public updaredAt?: Date
   ) {}
 }

--- a/src/domain/entities/AnswerView.ts
+++ b/src/domain/entities/AnswerView.ts
@@ -1,0 +1,19 @@
+import { Answer } from "./Answer";
+
+//클라이언트에게 전달할 것
+export class AnswerView extends Answer {
+  constructor(
+    userId: number,
+    questionId: number,
+    content: string, //사용자의 답변
+    createdAt: Date,
+    public nickName: string, //답변한 사용자
+    public avatar: string,
+    public isLike: boolean,
+    public likeCount: number = 0,
+    public question: string, //문제
+    public category: string //카테고리
+  ) {
+    super(userId, questionId, content, createdAt);
+  }
+}

--- a/src/domain/repositories/AnswerRepository.ts
+++ b/src/domain/repositories/AnswerRepository.ts
@@ -1,0 +1,27 @@
+import { Answer } from "../entities/Answer";
+import { AnswerView } from "../entities/AnswerView";
+
+interface UserAnswerParams {
+  userId: string;
+  questionId: number;
+}
+
+export interface AnswerRepository {
+  //답변 저장
+  createAnswer(answer: Answer): Promise<Answer>;
+
+  //답변 수정
+  updateAnswer(answer: Answer): Promise<Answer>;
+
+  //답변 삭제
+  deleteAnswer(params: UserAnswerParams): Promise<void>;
+
+  //유저의 특정 답변 조회
+  findUserAnswer(params: UserAnswerParams): Promise<AnswerView>;
+
+  //특정 문제의 답변 리스트 조회
+  findAnswersByQuestion(params: UserAnswerParams): Promise<Answer[]>;
+
+  //특정 유저의 답변 리스트 조회
+  findAllAnswersByUser(userId: number): Promise<Answer[]>;
+}

--- a/src/infra/repositories/supabase/SbAnswerRepository.ts
+++ b/src/infra/repositories/supabase/SbAnswerRepository.ts
@@ -55,7 +55,6 @@ export class SbAnswerRepository implements AnswerRepository {
       userId: data.email,
       questionId: data.question_id,
       content: data.content,
-      createdAt: new Date(data.created_at),
     };
   }
 

--- a/src/infra/repositories/supabase/SbAnswerRepository.ts
+++ b/src/infra/repositories/supabase/SbAnswerRepository.ts
@@ -65,7 +65,7 @@ export class SbAnswerRepository implements AnswerRepository {
     const { error } = await supabase
       .from("answer")
       .delete()
-      .eq("user_id", userId)
+      .eq("email", userId)
       .eq("question_id", questionId);
 
     if (error) {

--- a/src/infra/repositories/supabase/SbAnswerRepository.ts
+++ b/src/infra/repositories/supabase/SbAnswerRepository.ts
@@ -43,7 +43,7 @@ export class SbAnswerRepository implements AnswerRepository {
     const { data, error } = await supabase
       .from("answer")
       .update({ content: answer.content, updated_at: new Date().toISOString() })
-      .eq("user_id", answer.userId)
+      .eq("email", answer.userId)
       .eq("question_id", answer.questionId)
       .select()
       .single();
@@ -52,7 +52,7 @@ export class SbAnswerRepository implements AnswerRepository {
       throw new Error("답변 수정 실패.");
     }
     return {
-      userId: data.user_id,
+      userId: data.email,
       questionId: data.question_id,
       content: data.content,
       createdAt: new Date(data.created_at),

--- a/src/infra/repositories/supabase/SbAnswerRepository.ts
+++ b/src/infra/repositories/supabase/SbAnswerRepository.ts
@@ -23,7 +23,6 @@ export class SbAnswerRepository implements AnswerRepository {
       .select()
       .single();
 
-    console.error("Supabase 에러:", error);
     if (error) {
       console.error("답변 저장 실패:", error);
       throw new Error("답변 저장 실패.");

--- a/src/infra/repositories/supabase/SbAnswerRepository.ts
+++ b/src/infra/repositories/supabase/SbAnswerRepository.ts
@@ -1,0 +1,115 @@
+import { Answer } from "@/domain/entities/Answer";
+
+import { AnswerRepository } from "@/domain/repositories/AnswerRepository";
+import { supabase } from "@/utils/supabase/server";
+
+interface UserAnswerParams {
+  userId: string;
+  questionId: number;
+}
+
+export class SbAnswerRepository implements AnswerRepository {
+  //답변 저장
+  async createAnswer(answer: Answer): Promise<Answer> {
+    const { data, error } = await supabase
+      .from("answer")
+      .insert([
+        {
+          email: answer.userId,
+          question_id: answer.questionId,
+          content: answer.content,
+        },
+      ])
+      .select()
+      .single();
+
+    console.error("Supabase 에러:", error);
+    if (error) {
+      console.error("답변 저장 실패:", error);
+      throw new Error("답변 저장 실패.");
+    }
+
+    return {
+      userId: data.email,
+      questionId: data.question_id,
+      content: data.content,
+      createdAt: new Date(data.created_at),
+    };
+  }
+
+  //답변 수정
+  //특정 userId와 questionId 조합을 가진 답변 content 수정
+  async updateAnswer(answer: Answer): Promise<Answer> {
+    const { data, error } = await supabase
+      .from("answer")
+      .update({ content: answer.content, updated_at: new Date().toISOString() })
+      .eq("user_id", answer.userId)
+      .eq("question_id", answer.questionId)
+      .select()
+      .single();
+    if (error) {
+      console.error("답변 수정 실패:", error);
+      throw new Error("답변 수정 실패.");
+    }
+    return {
+      userId: data.user_id,
+      questionId: data.question_id,
+      content: data.content,
+      createdAt: new Date(data.created_at),
+    };
+  }
+
+  //답변 삭제
+  async deleteAnswer(params: UserAnswerParams): Promise<void> {
+    const { userId, questionId } = params;
+    const { error } = await supabase
+      .from("answer")
+      .delete()
+      .eq("user_id", userId)
+      .eq("question_id", questionId);
+
+    if (error) {
+      console.error("답변 삭제 실패:", error);
+      throw new Error("답변 삭제에 실패했습니다.");
+    }
+  }
+
+  //특정 유저의 특정 답변 조회
+  async findUserAnswer(params: UserAnswerParams): Promise<AnswerView> {}
+
+  //특정 문제의 답변 리스트 조회
+  async findAnswersByQuestion(params: UserAnswerParams): Promise<Answer[]> {
+    const { questionId } = params;
+    const { data, error } = await supabase
+      .from("answer")
+      .select("*")
+      .eq("question_id", questionId)
+      .order("created_at", { ascending: false }); // 최신순 정렬
+
+    if (error) {
+      console.error("답변 리스트 조회 실패:", error);
+      throw new Error("답변을 불러오지 못했습니다.");
+    }
+
+    if (!data) return [];
+
+    return data.map(
+      (item) => new Answer(item.user_id, item.question_id, item.content, new Date(item.created_at))
+    );
+  }
+
+  //특정 유저의 답변 리스트 조회
+  async findAllAnswersByUser(userId: number): Promise<Answer[]> {
+    const { data, error } = await supabase.from("answer").select("*").eq("user_id", userId);
+    if (error) {
+      console.error("답변 조회 실패:", error);
+      throw new Error("답변을 불러오지 못했습니다.");
+    }
+
+    if (!data) return [];
+
+    return data.map(
+      (item) => new Answer(item.user_id, item.question_id, item.content, new Date(item.created_at))
+    );
+  }
+}


### PR DESCRIPTION
## ✨ 작업 개요

문제 답변 페이지의 답변 저장, 수정, 삭제 기능을 구현했습니다.

## ✅ 상세 내용

### 1. (API Route) `api/answers/route.ts`
클라이언트의 요청을 처리하기 위한 API 로직을 추가했습니다.
- `POST` : 답변 등록
- `PUT` : 답변 수정
- `DELETE` : 답변 삭제

### 2. (UI) `questions/[questionid]/page.ts`
- 답변 저장/수정/삭제를 위한 API 요청 로직 구현


### 3. (Application Layer) `application/answer`
- UseCase 및 DTO 추가
```jsx
answer/
├── dto/
│   ├── CreateAnswerDto.ts        
│   ├── DeleteAnswerDto.ts    
│   ├── UpdateAnswerDto.ts
├── CreateAnswerUsecase.ts
├── DeleteAnswerUsecase.ts
└── UpdateAnswerUsecase.ts
```
### 4. (Domain Layer)
- `entities/Answer.ts`: 답변 엔티티 정의
- `repository/AnswerRepository.ts`: 답변 저장/수정/삭제를 위한 인터페이스 정의

### 5. (Infra Layer)
- `SbAnswerRepository`: Supabase 기반 답변 저장/수정/삭제 로직 구현

## 📸 스크린샷 (선택)

## 🧪 확인 사항

- [X] 정상적으로 동작하는지 직접 테스트해봤나요?
- [X] 기능 추가/수정 후 UI나 비즈니스 로직에 영향은 없나요?
- [X] PR 리뷰어가 중점적으로 확인하면 좋을 부분은?

## 🙏 기타 참고 사항

현재 `questionId`를 페이지 params로부터 불러오지 못하기 때문에, 
구글 로그인 후, 임시로 숫자를  사용하여 테스트 가능합니다~
```jsx
  const formData = {
  userId: userEmail,
  questionId:  // 이부분
  content,
};
```
추후 alert 변경 예정